### PR TITLE
replaced timeout decorator package and improved timeout execution

### DIFF
--- a/metadata_tools.py
+++ b/metadata_tools.py
@@ -1,5 +1,5 @@
 """metadata_tools: utility functions for the addition, removal and reading of iptc and exif image metadata"""
-from timeout_decorator import timeout
+from wrapt_timeout_decorator import timeout
 import errno
 import os
 import logging
@@ -8,12 +8,11 @@ import traceback
 from metadata_tools.EXIF_constants import EXIFConstants
 class MetadataTools:
 
-    @timeout(20, os.strerror(errno.ETIMEDOUT))
     def __init__(self, path):
         self.path = path
         self.logger = logging.getLogger('MetadataTools')
 
-
+    @timeout(20, os.strerror(errno.ETIMEDOUT))
     def read_exif_tags(self):
 
         """Reads all EXIF tags from an image using ExifTool with advanced formatting and returns them as a dictionary."""
@@ -38,6 +37,7 @@ class MetadataTools:
         finally:
             self.logger.info("EXIF data read successfully")
 
+    @timeout(20, os.strerror(errno.ETIMEDOUT))
     def write_exif_tags(self, exif_dict, overwrite_blank=False):
         """Writes all exif tags to an image with a single call to ExifTool"""
         self.logger.info(f"Processing EXIF data for: {self.path}")
@@ -64,4 +64,5 @@ class MetadataTools:
             traceback.print_exc()
             raise ValueError(f"ExifTool command returned with error: {e}")
         self.logger.info("EXIF data added successfully")
+
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ python-dateutil~=2.8.2
 pytz~=2021.3
 six~=1.16.0
 timeout~=0.1.2
-timeout-decorator~=0.5.0
+wrapt-timeout-decorator~=1.5.1
 tzdata~=2021.5
+


### PR DESCRIPTION
-Replaced @timeoutdecorator with a better and more recently maintained package (that pip can actually consistently find).
-Moved the timouts to the methods instead of the inits as no methods are called in the init anymore